### PR TITLE
Adding <?php to make PHP codes highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ PHP Sftp Client Class using SSH2 functions and shell commands, with server-side 
 
 ##### Connect to an SSH server & authenticate:
 ```php
+<?php
+
 // initialize
 $sftp = new \GR\SftpClient();
 
@@ -28,26 +30,36 @@ $sftp->login($user, $pass);
 
 ##### Get current directory:
 ```php
+<?php
+
 $sftp->getCurrentDirectory();
 ```
 
 ##### Create directory
 ```php
+<?php
+
 $sftp->createDirectory($path, $ignore_if_exists);
 ```
 
 ##### Delete directory
 ```php
+<?php
+
 $sftp->deleteDirectory($path);
 ```
 
 ##### Delete file
 ```php
+<?php
+
 $sftp->deleteFile($path);
 ```
 
 ##### Get directory content list
 ```php
+<?php
+
 // just names
 $sftp->getDirectoryList($path, $recursive);
 
@@ -60,21 +72,29 @@ $sftp->getDirectoryRawListFormatted($path, $recursive);
 
 ##### Get file stat
 ```php
-$stat = $sftp->stat($path); 
+<?php
+
+$stat = $sftp->stat($path);
 ```
 
 ##### Download a file
 ```php
-$sftp->downloadFile($remote_file, $local_file); 
+<?php
+
+$sftp->downloadFile($remote_file, $local_file);
 ```
 
 ##### Upload a file
 ```php
-$sftp->uploadFile($local_file, $remote_file[, int $create_mode = 0644 ] ); 
+<?php
+
+$sftp->uploadFile($local_file, $remote_file[, int $create_mode = 0644 ] );
 ```
 
 ##### Rename file/directory
 ```php
+<?php
+
 // Rename File
 $sftp->renameFile($oldname, $newname);
 
@@ -87,21 +107,29 @@ $sftp->renameFileOrFolder($oldname, $newname);
 
 ##### Create Symlink
 ```php
-$sftp->createSymlink($target, $link); 
+<?php
+
+$sftp->createSymlink($target, $link);
 ```
 
 ##### Execute custom command
 ```php
-$sftp->ssh2_exec($cmd); 
+<?php
+
+$sftp->ssh2_exec($cmd);
 ```
 
 ##### Close connection
 ```php
-$sftp->close(); 
+<?php
+
+$sftp->close();
 ```
 
 #### Handle Errors
 ```php
+<?php
+
 try {
 	$sftp = new \GR\SftpClient();
 	$sftp->connect($host, $port, $timeout);


### PR DESCRIPTION
# Changed log
- Adding `<?php` to define the head of PHP to make all PHP code snippets highlight on GitHub Markdown.